### PR TITLE
fix: typo in label element for input field

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -15,7 +15,7 @@
         <p data-test="description">This generator is only for testing purpose.</p>
         <form id="password-generator">
           <div class="box-1">
-            <label for="lenght">number of characters</label>
+            <label for="length">number of characters</label>
             <input type="number" id="length" value="16" min="8" max="24" />
           </div>
           <div class="box-2">


### PR DESCRIPTION
**Changelog:**

- fix a typo mistake for the label element for input field with `id="length"`
